### PR TITLE
Make irc-idler symlink in build.sh so that it is not owned by root.

### DIFF
--- a/.sandstorm/build.sh
+++ b/.sandstorm/build.sh
@@ -3,6 +3,16 @@ set -euo pipefail
 
 export GOPATH="/opt/app/.sandstorm/gopath"
 
+_srcdir="$GOPATH/src/zenhack.net/go/irc-idler"
+[ -L "$_srcdir" ] || {
+       mkdir -p $(dirname $_srcdir) || true
+       cd $(dirname _srcdir)
+       # Make a symlink back to /opt/app. We do this as
+       # a relative path so we can play with it on the
+       # host machine more easily.
+       ln -s ../../../../..  $_srcdir
+}
+
 # To pull in the dependencies:
 go get -d zenhack.net/go/irc-idler/cmd/sandstorm-irc-idler
 

--- a/.sandstorm/setup.sh
+++ b/.sandstorm/setup.sh
@@ -13,16 +13,4 @@ apt-get update
 apt-get install -y git
 apt-get -t jessie-backports install -y golang
 
-export GOPATH="/opt/app/.sandstorm/gopath"
-_srcdir="$GOPATH/src/zenhack.net/go/irc-idler"
-[ -L "$_srcdir" ] || {
-       mkdir -p $(dirname $_srcdir) || true
-       cd $(dirname _srcdir)
-       # Make a symlink back to /opt/app. We do this as
-       # a relative path so we can play with it on the
-       # host machine more easily.
-       ln -s ../../../../..  $_srcdir
-}
-
-set -euo pipefail
 exit 0


### PR DESCRIPTION
When I try to run the app through `vagrant-spk` I get the following error:

```
$ vagrant-spk vm up
...
$ vagrant-spk dev
Calling 'vagrant' 'ssh' '-c' '/opt/app/.sandstorm/build.sh && cd /opt/app/.sandstorm && spk dev --pkg-def=/opt/app/.sandstorm/sandstorm-pkgdef.capnp:pkgdef' in /home/dwrensha/go-workspace/src/irc-idler/.sandstorm
package github.com/Sirupsen/logrus: mkdir /opt/app/.sandstorm/gopath/src/github.com: permission denied
package github.com/mattn/go-sqlite3: mkdir /opt/app/.sandstorm/gopath/src/github.com: permission denied
package golang.org/x/net/context: mkdir /opt/app/.sandstorm/gopath/src/golang.org: permission denied
package github.com/gorilla/mux: mkdir /opt/app/.sandstorm/gopath/src/github.com: permission denied
package github.com/gorilla/schema: mkdir /opt/app/.sandstorm/gopath/src/github.com: permission denied
package golang.org/x/net/websocket: cannot find package "golang.org/x/net/websocket" in any of:
        /usr/lib/go-1.6/src/golang.org/x/net/websocket (from $GOROOT)
        /opt/app/.sandstorm/gopath/src/golang.org/x/net/websocket (from $GOPATH)
package golang.org/x/net/xsrftoken: cannot find package "golang.org/x/net/xsrftoken" in any of:
        /usr/lib/go-1.6/src/golang.org/x/net/xsrftoken (from $GOROOT)
        /opt/app/.sandstorm/gopath/src/golang.org/x/net/xsrftoken (from $GOPATH)
# cd .; git clone https://github.com/zenhack/go.sandstorm /opt/app/.sandstorm/gopath/src/zenhack.net/go/sandstorm
fatal: could not create work tree dir '/opt/app/.sandstorm/gopath/src/zenhack.net/go/sandstorm'.: Permission denied
package zenhack.net/go/sandstorm/capnp/grain: exit status 128
package zenhack.net/go/sandstorm/capnp/websession: cannot find package "zenhack.net/go/sandstorm/capnp/websession" in any of:
        /usr/lib/go-1.6/src/zenhack.net/go/sandstorm/capnp/websession (from $GOROOT)
        /opt/app/.sandstorm/gopath/src/zenhack.net/go/sandstorm/capnp/websession (from $GOPATH)
package zenhack.net/go/sandstorm/websession: cannot find package "zenhack.net/go/sandstorm/websession" in any of:
        /usr/lib/go-1.6/src/zenhack.net/go/sandstorm/websession (from $GOROOT)
        /opt/app/.sandstorm/gopath/src/zenhack.net/go/sandstorm/websession (from $GOPATH)
package zombiezen.com/go/capnproto2: mkdir /opt/app/.sandstorm/gopath/src/zombiezen.com: permission denied
package zenhack.net/go/sandstorm/capnp/ip: cannot find package "zenhack.net/go/sandstorm/capnp/ip" in any of:
        /usr/lib/go-1.6/src/zenhack.net/go/sandstorm/capnp/ip (from $GOROOT)
        /opt/app/.sandstorm/gopath/src/zenhack.net/go/sandstorm/capnp/ip (from $GOPATH)
package zenhack.net/go/sandstorm/grain: cannot find package "zenhack.net/go/sandstorm/grain" in any of:
        /usr/lib/go-1.6/src/zenhack.net/go/sandstorm/grain (from $GOROOT)
        /opt/app/.sandstorm/gopath/src/zenhack.net/go/sandstorm/grain (from $GOPATH)
package zenhack.net/go/sandstorm/ip: cannot find package "zenhack.net/go/sandstorm/ip" in any of:
        /usr/lib/go-1.6/src/zenhack.net/go/sandstorm/ip (from $GOROOT)
        /opt/app/.sandstorm/gopath/src/zenhack.net/go/sandstorm/ip (from $GOPATH)
Connection to 192.168.121.38 closed.
Traceback (most recent call last):
  File "/usr/local/bin/vagrant-spk", line 1028, in <module>
    main()
  File "/usr/local/bin/vagrant-spk", line 1025, in main
    operation(args)
  File "/usr/local/bin/vagrant-spk", line 680, in dev
    "spk dev --pkg-def=/opt/app/.sandstorm/sandstorm-pkgdef.capnp:pkgdef"
  File "/usr/local/bin/vagrant-spk", line 294, in call_vagrant_command
    return subprocess.check_call(command, cwd=sandstorm_dir)
  File "/usr/lib64/python2.7/subprocess.py", line 541, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['vagrant', 'ssh', '-c', '/opt/app/.sandstorm/build.sh && cd /opt/app/.sandstorm && spk dev --pkg-def=/opt/app/.sandstorm/sandstorm-pkgdef.capnp:pkgdef']' returned non-zero exit status 1

```

The issue is that `setup.sh` is run as root, so `/opt/app/.sandstorm/gopath/` ends up owned by root:root. Then when `build.sh` runs as non-root `go get` fails because it can't write.
